### PR TITLE
feat(sink-http): added support for custom HTTP headers

### DIFF
--- a/examples/basic/pkl/PklProject
+++ b/examples/basic/pkl/PklProject
@@ -2,6 +2,6 @@ amends "pkl:Project"
 
 dependencies {
   ["pipelaner"] {
-    uri = "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.4"
+    uri = "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.5"
   }
 }

--- a/examples/basic/pkl/PklProject.deps.json
+++ b/examples/basic/pkl/PklProject.deps.json
@@ -3,7 +3,7 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.4",
+      "uri": "projectpackage://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.5",
       "checksums": {
         "sha256": "b8bec65b54b44ea4d43d61b12815e013d09480c5ac888c6cabedbcd9c0484d19"
       }

--- a/examples/basic/pkl/config.pkl
+++ b/examples/basic/pkl/config.pkl
@@ -1,8 +1,8 @@
-amends "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.4#/Pipelaner.pkl"
-import "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.4#/source/Components.pkl"
-import "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.4#/source/sink/Sinks.pkl"
-import "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.4#/source/input/Inputs.pkl"
-import "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.4#/source/transform/Transforms.pkl"
+amends "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.5#/Pipelaner.pkl"
+import "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.5#/source/Components.pkl"
+import "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.5#/source/sink/Sinks.pkl"
+import "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.5#/source/input/Inputs.pkl"
+import "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.5#/source/transform/Transforms.pkl"
 
 pipelines {
   new Components.Pipeline {

--- a/examples/custom/pkl/PklProject
+++ b/examples/custom/pkl/PklProject
@@ -2,6 +2,6 @@ amends "pkl:Project"
 
 dependencies {
   ["pipelaner"] {
-    uri = "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.4"
+    uri = "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.5"
   }
 }

--- a/examples/custom/pkl/PklProject.deps.json
+++ b/examples/custom/pkl/PklProject.deps.json
@@ -3,7 +3,7 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.4",
+      "uri": "projectpackage://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.5",
       "checksums": {
         "sha256": "b8bec65b54b44ea4d43d61b12815e013d09480c5ac888c6cabedbcd9c0484d19"
       }

--- a/examples/custom/pkl/config.pkl
+++ b/examples/custom/pkl/config.pkl
@@ -1,6 +1,6 @@
-amends "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.4#/Pipelaner.pkl"
-import "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.4#/source/Components.pkl"
-import "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.4#/source/sink/Sinks.pkl"
+amends "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.5#/Pipelaner.pkl"
+import "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.5#/source/Components.pkl"
+import "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.5#/source/sink/Sinks.pkl"
 import "custom.pkl"
 
 pipelines {

--- a/examples/custom/pkl/custom.pkl
+++ b/examples/custom/pkl/custom.pkl
@@ -2,9 +2,9 @@
 module pipelaner.source.examples.custom
 
 import "package://pkg.pkl-lang.org/pkl-go/pkl.golang@0.9.0#/go.pkl"
-import "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.4#/source/input/Inputs.pkl"
-import "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.4#/source/sink/Sinks.pkl"
-import "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.4#/source/transform/Transforms.pkl"
+import "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.5#/source/input/Inputs.pkl"
+import "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.5#/source/sink/Sinks.pkl"
+import "package://pkg.pkl-lang.org/github.com/pipelane/pipelaner/pipelaner@1.0.5#/source/transform/Transforms.pkl"
 
 class ExampleGenInt extends Inputs.Input {
   fixed sourceName = "example-generator"

--- a/gen/source/sink/Http.pkl.go
+++ b/gen/source/sink/Http.pkl.go
@@ -9,6 +9,8 @@ type Http interface {
 	GetUrl() string
 
 	GetMethod() method.Method
+
+	GetHeaders() *map[string]string
 }
 
 var _ Http = (*HttpImpl)(nil)
@@ -19,6 +21,8 @@ type HttpImpl struct {
 	Url string `pkl:"url"`
 
 	Method method.Method `pkl:"method"`
+
+	Headers *map[string]string `pkl:"headers"`
 
 	Name string `pkl:"name"`
 
@@ -37,6 +41,10 @@ func (rcv *HttpImpl) GetUrl() string {
 
 func (rcv *HttpImpl) GetMethod() method.Method {
 	return rcv.Method
+}
+
+func (rcv *HttpImpl) GetHeaders() *map[string]string {
+	return rcv.Headers
 }
 
 func (rcv *HttpImpl) GetName() string {

--- a/pkl/PklProject
+++ b/pkl/PklProject
@@ -2,7 +2,7 @@ amends "pkl:Project"
 
 package {
   name = "pipelaner"
-  version = "1.0.4"
+  version = "1.0.5"
   baseUri = "package://pipelane.github.com/pipelaner"
   sourceCode = "https://github.com/pipelane/pipelaner"
   packageZipUrl = "https://github.com/pipelane/pipelaner/releases/download/\(name)@\(version)/\(name)@\(version).zip"

--- a/pkl/source/sink/Sinks.pkl
+++ b/pkl/source/sink/Sinks.pkl
@@ -47,4 +47,12 @@ class Http extends Sink {
   fixed sourceName = "http"
   url: String(!isEmpty)
   method: Method
+  headers: Mapping<String, String>?
+}
+
+
+hh = new Mapping {
+  ["Authorization"] {
+    "Bearer \(read("env:"))"
+  }
 }

--- a/sources/sink/http/README.md
+++ b/sources/sink/http/README.md
@@ -1,7 +1,7 @@
 
 # **HTTP**
 
-The **HTTP** sink component sends incoming messages to an HTTP endpoint using a specified method.
+The **HTTP** sink component sends incoming messages to an HTTP endpoint using a specified method and optional headers.
 
 ---
 
@@ -14,6 +14,7 @@ class Http extends Sink {
   fixed sourceName = "http"
   url: String
   method: Method
+  headers: Mapping<String, String>
 }
 ```
 
@@ -21,10 +22,11 @@ class Http extends Sink {
 
 ## **Attributes**
 
-| **Attribute** | **Type**   | **Description**                                                   | **Default Value** |
-|---------------|------------|-------------------------------------------------------------------|--------------------|
-| `url`         | `String`   | The URL of the HTTP endpoint.                                     | **Required**      |
-| `method`      | `Method`   | The HTTP method to use (`PATCH`, `POST`, `PUT`, `DELETE`, `GET`). | **Required**      |
+| **Attribute** | **Type**                 | **Description**                                                   | **Default Value** |
+|---------------|--------------------------|-------------------------------------------------------------------|--------------------|
+| `url`         | `String`                 | The URL of the HTTP endpoint.                                     | **Required**      |
+| `method`      | `Method`                 | The HTTP method to use (`PATCH`, `POST`, `PUT`, `DELETE`, `GET`). | **Required**      |
+| `headers`     | `Mapping<String,String>` | A mapping of HTTP headers to include in the request.              | `{}` (empty map)  |
 
 ---
 
@@ -43,6 +45,14 @@ new Http {
   name = "example-http"
   url = "https://example.com/api"
   method = "POST"
+  headers = new Mapping {
+     ["Authorization"] {
+        "Bearer \(read("env:AUTH_TOKEN"))"
+     }
+     ["Content-Type"] {
+        "application/json"
+     }
+  }
 }
 ```
 
@@ -52,6 +62,11 @@ new Http {
   name = "example-http-get"
   url = "https://example.com/resource"
   method = "GET"
+  headers = new Mapping {
+     ["Accept"] {
+        "application/json"
+     }
+  }
 }
 ```
 
@@ -59,18 +74,20 @@ new Http {
 
 ## **Description**
 
-The **HTTP** sink sends messages to an HTTP endpoint using the specified method. It is versatile and can be used for various purposes such as sending data, triggering APIs, or deleting resources.
+The **HTTP** sink sends messages to an HTTP endpoint using the specified method. Optional headers can be used to customize requests for specific APIs or services. This sink is versatile and can be used for various purposes such as sending data, triggering APIs, or managing resources.
 
 ---
 
 ### **Use Cases**
 
 1. **Data Transmission**
-    - Send processed data to an API for further processing or storage.
+   - Send processed data to an API for further processing or storage.
 2. **Triggering Webhooks**
-    - Use methods like `POST` or `PATCH` to trigger webhooks with pipeline data.
+   - Use methods like `POST` or `PATCH` to trigger webhooks with pipeline data.
 3. **Resource Management**
-    - Use methods like `DELETE` or `PUT` to manage resources on a remote server.
+   - Use methods like `DELETE` or `PUT` to manage resources on a remote server.
+4. **Authenticated Requests**
+   - Add authentication headers (e.g., `Authorization`) for secure communication with APIs.
 
 ---
 
@@ -78,6 +95,7 @@ The **HTTP** sink sends messages to an HTTP endpoint using the specified method.
 
 - Ensure the `url` attribute points to a valid HTTP endpoint.
 - The `method` attribute must match the desired HTTP operation.
+- Use the `headers` attribute to include custom headers like `Authorization` or `Content-Type` as required by your API.
 
 ---
 

--- a/sources/sink/http/http.go
+++ b/sources/sink/http/http.go
@@ -29,7 +29,6 @@ func (c *Client) Init(cfg sink.Sink) error {
 	if !ok {
 		return fmt.Errorf("invalid http client config %T", cfg)
 	}
-
 	c.cfg = httpCfg
 	c.cli = resty.New()
 	return nil
@@ -40,6 +39,9 @@ func (c *Client) Sink(val any) {
 	switch c.cfg.GetMethod() {
 	case method.POST, method.PUT, method.PATCH, method.DELETE:
 		r.SetBody(val)
+	}
+	if c.cfg.GetHeaders() != nil {
+		r = r.SetHeaders(*c.cfg.GetHeaders())
 	}
 	m := c.method(r)
 	resp, err := m(c.cfg.GetUrl())


### PR DESCRIPTION
- Added `headers` attribute to the `Http` sink configuration to enable custom HTTP headers.
- Updated documentation to include examples of using the `headers` attribute.
- Ensures flexibility for API integrations requiring authentication or custom header configuration.